### PR TITLE
Fix broken links in section-7-playground.html

### DIFF
--- a/docs/section-7-playground.html
+++ b/docs/section-7-playground.html
@@ -54,12 +54,12 @@ permalink: playground
 <h4 id="about">About </h4>
 <p>You can try out tree-sitter with a few pre-selected grammars on this page.
   You can also run playground locally (with your own grammar) using the
-  <a href="/creating-parsers">CLI</a>'s <code>tree-sitter playground</code> subcommand.</p>
+  <a href="./creating-parsers">CLI</a>'s <code>tree-sitter playground</code> subcommand.</p>
 <p>The syntax tree should update as you type in the code. As you move around the
   code, the current node should be highlighted in the tree; you can also click any
   node in the tree to select the corresponding part of the code.</p>
 <p>Logging (if enabled) can be viewed in the browser's console.</p>
-<p>You can enter one or more <a href="/using-parsers#pattern-matching-with-queries">patterns</a>
+<p>You can enter one or more <a href="./using-parsers#pattern-matching-with-queries">patterns</a>
   into the Query panel. If the query is valid, its captures will be
   highlighted both in the Code and in the Query panels. Otherwise
   the problematic parts of the query will be underlined, and detailed


### PR DESCRIPTION
As a follow-up to #1495, I just noticed the added links were absolute, not relative, resolving to (for example) https://tree-sitter.github.io/creating-parsers instead of https://tree-sitter.github.io/tree-sitter/creating-parsers and resulting in 404 errors. Sorry for not paying attention! :(